### PR TITLE
fix: get series when get artworks by exhibitionID by /api/artworks

### DIFF
--- a/lib/model/ff_account.dart
+++ b/lib/model/ff_account.dart
@@ -274,6 +274,50 @@ class Artwork {
 
   Map<String, dynamic> toJson() => _$ArtworkToJson(this);
 
+  // copyWith method
+  Artwork copyWith({
+    String? id,
+    String? seriesID,
+    int? index,
+    String? name,
+    String? category,
+    String? ownerAccountID,
+    bool? virgin,
+    bool? burned,
+    String? blockchainStatus,
+    bool? isExternal,
+    String? thumbnailURI,
+    String? previewURI,
+    Map<String, dynamic>? metadata,
+    DateTime? mintedAt,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    bool? isArchived,
+    FFSeries? series,
+    ArtworkSwap? swap,
+  }) =>
+      Artwork(
+        id ?? this.id,
+        seriesID ?? this.seriesID,
+        index ?? this.index,
+        name ?? this.name,
+        category ?? this.category,
+        ownerAccountID ?? this.ownerAccountID,
+        virgin ?? this.virgin,
+        burned ?? this.burned,
+        blockchainStatus ?? this.blockchainStatus,
+        isExternal ?? this.isExternal,
+        thumbnailURI ?? this.thumbnailURI,
+        previewURI ?? this.previewURI,
+        metadata ?? this.metadata,
+        mintedAt ?? this.mintedAt,
+        createdAt ?? this.createdAt,
+        updatedAt ?? this.updatedAt,
+        isArchived ?? this.isArchived,
+        series ?? this.series,
+        swap ?? this.swap,
+      );
+
   static Artwork createFake(
           String thumbNailURI, String previewURI, String medium) =>
       Artwork(

--- a/lib/screen/exhibition_details/exhibition_detail_bloc.dart
+++ b/lib/screen/exhibition_details/exhibition_detail_bloc.dart
@@ -15,7 +15,8 @@ class ExhibitionDetailBloc
     on<GetExhibitionDetailEvent>((event, emit) async {
       final result = await Future.wait([
         _feralFileService.getExhibition(event.exhibitionId),
-        _feralFileService.getExhibitionArtworks(event.exhibitionId)
+        _feralFileService.getExhibitionArtworks(event.exhibitionId,
+            withSeries: true)
       ]);
       final exhibitionDetail = ExhibitionDetail(
           exhibition: result[0] as Exhibition,


### PR DESCRIPTION
**Description**

- Story link: https://github.com/bitmark-inc/autonomy/issues/<number>

**Describe your changes**

- [ ] Added a function A to process data B
- [ ] Created new column C to store D state
- [ ] Refactor workflow E to improve performance because of F
