### PR TITLE
fix: android delete keys when forget i exist

### DIFF
--- a/android/app/src/main/kotlin/com/bitmark/autonomy_flutter/BackupDartPlugin.kt
+++ b/android/app/src/main/kotlin/com/bitmark/autonomy_flutter/BackupDartPlugin.kt
@@ -17,11 +17,9 @@ import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.reactivex.Completable
-import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.disposables.CompositeDisposable
 import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 import java.util.*
 
 class BackupDartPlugin : MethodChannel.MethodCallHandler {
@@ -174,7 +172,7 @@ class BackupDartPlugin : MethodChannel.MethodCallHandler {
     private fun deleteKeys(call: MethodCall, result: MethodChannel.Result) {
         // store empty bytes to blockstore
         val storeBytesDataBuilder = StoreBytesData.Builder()
-            .setBytes("".toByteArray(Charsets.UTF_8))
+            .setBytes(ByteArray(0))
         client.storeBytes(storeBytesDataBuilder.build())
             .addOnSuccessListener {
                 result.success("")

--- a/android/app/src/main/kotlin/com/bitmark/autonomy_flutter/BackupDartPlugin.kt
+++ b/android/app/src/main/kotlin/com/bitmark/autonomy_flutter/BackupDartPlugin.kt
@@ -47,6 +47,7 @@ class BackupDartPlugin : MethodChannel.MethodCallHandler {
             "isEndToEndEncryptionAvailable" -> isEndToEndEncryptionAvailable(result)
             "backupKeys" -> backupKeys(call, result)
             "restoreKeys" -> restoreKeys(call, result)
+            "deleteKeys" -> deleteKeys(call, result)
             else -> {
                 result.notImplemented()
             }
@@ -166,6 +167,21 @@ class BackupDartPlugin : MethodChannel.MethodCallHandler {
             .addOnFailureListener {
                 //Block store not available
                 result.error("restoreKey error", it.message, it)
+            }
+    }
+
+
+    private fun deleteKeys(call: MethodCall, result: MethodChannel.Result) {
+        // store empty bytes to blockstore
+        val storeBytesDataBuilder = StoreBytesData.Builder()
+            .setBytes("".toByteArray(Charsets.UTF_8))
+        client.storeBytes(storeBytesDataBuilder.build())
+            .addOnSuccessListener {
+                result.success("")
+            }
+            .addOnFailureListener { e ->
+                Log.e("BackupDartPlugin", e.message ?: "")
+                result.error("deleteKeys error", e.message, e)
             }
     }
 }

--- a/lib/screen/settings/forget_exist/forget_exist_bloc.dart
+++ b/lib/screen/settings/forget_exist/forget_exist_bloc.dart
@@ -76,6 +76,7 @@ class ForgetExistBloc extends AuBloc<ForgetExistEvent, ForgetExistState> {
       await injector<CacheManager>().emptyCache();
       await DefaultCacheManager().emptyCache();
       await injector<KeychainService>().clearKeychainItems();
+      await injector<AccountService>().deleteAllKeys();
 
       await FileLogger.clear();
       await SentryBreadcrumbLogger.clear();

--- a/lib/service/account_service.dart
+++ b/lib/service/account_service.dart
@@ -57,6 +57,8 @@ abstract class AccountService {
 
   Future androidBackupKeys();
 
+  Future deleteAllKeys();
+
   Future<List<Connection>> removeDoubleViewOnly(List<String> addresses);
 
   Future<bool?> isAndroidEndToEndEncryptionAvailable();
@@ -389,6 +391,13 @@ class AccountServiceImpl extends AccountService {
       final uuids = accounts.map((e) => e.uuid).toList();
 
       await _backupChannel.backupKeys(uuids);
+    }
+  }
+
+  @override
+  Future deleteAllKeys() async {
+    if (Platform.isAndroid) {
+      await _backupChannel.deleteAllKeys();
     }
   }
 

--- a/lib/util/android_backup_channel.dart
+++ b/lib/util/android_backup_channel.dart
@@ -38,6 +38,14 @@ class AndroidBackupChannel {
       return [];
     }
   }
+
+  Future deleteAllKeys() async {
+    try {
+      await _channel.invokeMethod('deleteKeys', {});
+    } catch (e) {
+      log.warning("Android cloud backup error", e);
+    }
+  }
 }
 
 class BackupData {


### PR DESCRIPTION
**Description**

- Story link: [Forget I exist functionality does not delete keys from backup](https://github.com/autonomy-system/autonomy-mobile-security-audit/issues/10)
**Describe your changes**

- [ ] Added a function A to process data B
- [ ] Created new column C to store D state
- [ ] Refactor workflow E to improve performance because of F
