### PR TITLE
fix: tbSignMessagePage return type can be string

### DIFF
--- a/lib/service/tezos_beacon_service.dart
+++ b/lib/service/tezos_beacon_service.dart
@@ -155,7 +155,7 @@ class TezosBeaconService implements BeaconHandler {
       final result = await _navigationService
           .navigateTo(AppRouter.tbSignMessagePage, arguments: request);
       log.info('TezosBeaconService: handle permission Request result: $result');
-      if (result) {
+      if (result is String || result == true) {
         _showYouAllSet();
       }
       _clearConnectFlag();


### PR DESCRIPTION
**Description**

- Story link: https://github.com/bitmark-inc/autonomy/issues/<number>

**Describe your changes**

- [ ] Added a function A to process data B
- [ ] Created new column C to store D state
- [ ] Refactor workflow E to improve performance because of F
