### PR TITLE
fix: sync subscription status in exhibitions page

### DIFF
--- a/lib/common/injector.dart
+++ b/lib/common/injector.dart
@@ -27,6 +27,7 @@ import 'package:autonomy_flutter/gateway/pubdoc_api.dart';
 import 'package:autonomy_flutter/gateway/source_exhibition_api.dart';
 import 'package:autonomy_flutter/gateway/tzkt_api.dart';
 import 'package:autonomy_flutter/screen/bloc/identity/identity_bloc.dart';
+import 'package:autonomy_flutter/screen/bloc/subscription/subscription_bloc.dart';
 import 'package:autonomy_flutter/screen/chat/chat_bloc.dart';
 import 'package:autonomy_flutter/screen/collection_pro/collection_pro_bloc.dart';
 import 'package:autonomy_flutter/screen/detail/preview/canvas_device_bloc.dart';
@@ -397,4 +398,6 @@ Future<void> setup() async {
       () => CanvasDeviceBloc(injector(), injector(), injector()));
   injector
       .registerLazySingleton<ExhibitionBloc>(() => ExhibitionBloc(injector()));
+  injector.registerLazySingleton<SubscriptionBloc>(
+      () => SubscriptionBloc(injector()));
 }

--- a/lib/screen/bloc/subscription/subscription_bloc.dart
+++ b/lib/screen/bloc/subscription/subscription_bloc.dart
@@ -1,0 +1,15 @@
+import 'package:autonomy_flutter/au_bloc.dart';
+import 'package:autonomy_flutter/screen/bloc/subscription/subscription_state.dart';
+import 'package:autonomy_flutter/service/iap_service.dart';
+
+class SubscriptionBloc extends AuBloc<SubscriptionEvent, SubscriptionState> {
+  final IAPService _iapService;
+  SubscriptionBloc(this._iapService) : super(SubscriptionState()) {
+    on<GetSubscriptionEvent>((event, emit) async {
+      final isSubscribed = await _iapService.isSubscribed();
+      emit(state.copyWith(
+        isSubscribed: isSubscribed,
+      ));
+    });
+  }
+}

--- a/lib/screen/bloc/subscription/subscription_state.dart
+++ b/lib/screen/bloc/subscription/subscription_state.dart
@@ -1,0 +1,18 @@
+class SubscriptionEvent {}
+
+class GetSubscriptionEvent extends SubscriptionEvent {}
+
+class SubscriptionState {
+  SubscriptionState({
+    this.isSubscribed = false,
+  });
+
+  final bool isSubscribed;
+
+  SubscriptionState copyWith({
+    bool? isSubscribed,
+  }) =>
+      SubscriptionState(
+        isSubscribed: isSubscribed ?? this.isSubscribed,
+      );
+}

--- a/lib/screen/exhibitions/exhibitions_bloc.dart
+++ b/lib/screen/exhibitions/exhibitions_bloc.dart
@@ -1,9 +1,7 @@
 import 'package:autonomy_flutter/au_bloc.dart';
-import 'package:autonomy_flutter/common/injector.dart';
 import 'package:autonomy_flutter/model/ff_exhibition.dart';
 import 'package:autonomy_flutter/screen/exhibitions/exhibitions_state.dart';
 import 'package:autonomy_flutter/service/feralfile_service.dart';
-import 'package:autonomy_flutter/service/iap_service.dart';
 import 'package:autonomy_flutter/util/constants.dart';
 import 'package:autonomy_flutter/util/exhibition_ext.dart';
 import 'package:autonomy_flutter/util/log.dart';
@@ -19,15 +17,13 @@ class ExhibitionBloc extends AuBloc<ExhibitionsEvent, ExhibitionsState> {
         return;
       }
       final result = await Future.wait([
-        injector.get<IAPService>().isSubscribed(),
         _feralFileService.getFeaturedExhibition(),
         _feralFileService.getAllExhibitions(limit: limit),
         _feralFileService.getSourceExhibition(withSeries: false),
       ]);
-      final isSubscribed = result[0] as bool;
-      final featuredExhibition = result[1] as Exhibition;
-      var proExhibitions = result[2] as List<Exhibition>;
-      final sourceExhibition = result[3] as Exhibition;
+      final featuredExhibition = result[0] as Exhibition;
+      var proExhibitions = result[1] as List<Exhibition>;
+      final sourceExhibition = result[2] as Exhibition;
       log.info('[ExhibitionBloc] getAllExhibitionsEvent:'
           ' pro ${proExhibitions.length}');
       proExhibitions
@@ -37,7 +33,6 @@ class ExhibitionBloc extends AuBloc<ExhibitionsEvent, ExhibitionsState> {
       emit(state.copyWith(
         freeExhibitions: [featuredExhibition],
         proExhibitions: proExhibitions,
-        isSubscribed: isSubscribed,
         currentPage: 1,
         sourceExhibition: sourceExhibition,
       ));

--- a/lib/screen/exhibitions/exhibitions_state.dart
+++ b/lib/screen/exhibitions/exhibitions_state.dart
@@ -16,7 +16,6 @@ class ExhibitionsState {
   ExhibitionsState({
     this.freeExhibitions,
     this.proExhibitions,
-    this.isSubscribed = false,
     this.currentPage = 0,
     this.sourceExhibition,
   });
@@ -24,7 +23,6 @@ class ExhibitionsState {
   final List<Exhibition>? freeExhibitions;
   final List<Exhibition>? proExhibitions;
   final Exhibition? sourceExhibition;
-  final bool isSubscribed;
   final int currentPage;
 
   ExhibitionsState copyWith({
@@ -37,7 +35,6 @@ class ExhibitionsState {
       ExhibitionsState(
         freeExhibitions: freeExhibitions ?? this.freeExhibitions,
         proExhibitions: proExhibitions ?? this.proExhibitions,
-        isSubscribed: isSubscribed ?? this.isSubscribed,
         currentPage: currentPage ?? this.currentPage,
         sourceExhibition: sourceExhibition ?? this.sourceExhibition,
       );

--- a/lib/screen/home/home_navigation_page.dart
+++ b/lib/screen/home/home_navigation_page.dart
@@ -14,6 +14,8 @@ import 'package:autonomy_flutter/database/cloud_database.dart';
 import 'package:autonomy_flutter/database/entity/announcement_local.dart';
 import 'package:autonomy_flutter/main.dart';
 import 'package:autonomy_flutter/screen/app_router.dart';
+import 'package:autonomy_flutter/screen/bloc/subscription/subscription_bloc.dart';
+import 'package:autonomy_flutter/screen/bloc/subscription/subscription_state.dart';
 import 'package:autonomy_flutter/screen/customer_support/support_thread_page.dart';
 import 'package:autonomy_flutter/screen/detail/artwork_detail_page.dart';
 import 'package:autonomy_flutter/screen/detail/preview/canvas_device_bloc.dart';
@@ -283,6 +285,9 @@ class HomeNavigationPageState extends State<HomeNavigationPage>
       MultiBlocProvider(providers: [
         BlocProvider.value(
           value: injector<ExhibitionBloc>()..add(GetAllExhibitionsEvent()),
+        ),
+        BlocProvider.value(
+          value: injector<SubscriptionBloc>()..add(GetSubscriptionEvent()),
         ),
       ], child: const ExhibitionsPage()),
       ScanQRPage(

--- a/lib/util/exhibition_ext.dart
+++ b/lib/util/exhibition_ext.dart
@@ -3,6 +3,7 @@ import 'package:autonomy_flutter/common/injector.dart';
 import 'package:autonomy_flutter/model/ff_account.dart';
 import 'package:autonomy_flutter/model/ff_exhibition.dart';
 import 'package:autonomy_flutter/model/ff_series.dart';
+import 'package:autonomy_flutter/screen/bloc/subscription/subscription_bloc.dart';
 import 'package:autonomy_flutter/screen/exhibitions/exhibitions_bloc.dart';
 import 'package:autonomy_flutter/service/feralfile_service.dart';
 import 'package:autonomy_flutter/service/remote_config_service.dart';
@@ -21,7 +22,8 @@ extension ExhibitionExt on Exhibition {
 
   bool get canViewDetails {
     final exhibitionBloc = injector<ExhibitionBloc>();
-    return exhibitionBloc.state.isSubscribed ||
+    final subscriptionBloc = injector<SubscriptionBloc>();
+    return subscriptionBloc.state.isSubscribed ||
         (exhibitionBloc.state.freeExhibitions
                 ?.any((element) => element.id == id) ??
             false);


### PR DESCRIPTION
**Description**

- Story link: [[Bug] FFapp - "Get Premium" button does not update to reflect the new subscription till user kill app and reopen the application #2478](https://github.com/bitmark-inc/feral-file/issues/2478)

**Describe your changes**

- [X] Sync subscription status in exhibitions page
