### PR TITLE
fix: always get series for source exhibition

### DIFF
--- a/lib/screen/exhibitions/exhibitions_bloc.dart
+++ b/lib/screen/exhibitions/exhibitions_bloc.dart
@@ -19,7 +19,7 @@ class ExhibitionBloc extends AuBloc<ExhibitionsEvent, ExhibitionsState> {
       final result = await Future.wait([
         _feralFileService.getFeaturedExhibition(),
         _feralFileService.getAllExhibitions(limit: limit),
-        _feralFileService.getSourceExhibition(withSeries: false),
+        _feralFileService.getSourceExhibition(),
       ]);
       final featuredExhibition = result[0] as Exhibition;
       var proExhibitions = result[1] as List<Exhibition>;

--- a/lib/service/feralfile_service.dart
+++ b/lib/service/feralfile_service.dart
@@ -140,7 +140,7 @@ abstract class FeralFileService {
     int offset = 0,
   });
 
-  Future<Exhibition> getSourceExhibition({bool withSeries = true});
+  Future<Exhibition> getSourceExhibition();
 
   Future<Exhibition> getFeaturedExhibition();
 
@@ -500,16 +500,12 @@ class FeralFileServiceImpl extends FeralFileService {
 
   // Source Exhibition
   @override
-  Future<Exhibition> getSourceExhibition({bool withSeries = true}) async {
+  Future<Exhibition> getSourceExhibition() async {
     if (sourceExhibition != null) {
       return sourceExhibition!;
     }
 
     final exhibition = await _sourceExhibitionAPI.getSourceExhibitionInfo();
-    if (!withSeries) {
-      sourceExhibition = exhibition;
-      return sourceExhibition!;
-    }
     final series = await _sourceExhibitionAPI.getSourceExhibitionSeries();
     sourceExhibition = exhibition.copyWith(series: series);
     return sourceExhibition!;


### PR DESCRIPTION
**Description**

- Story link: https://github.com/bitmark-inc/autonomy/issues/<number>

**Describe your changes**

- [ ] Added a function A to process data B
- [ ] Created new column C to store D state
- [ ] Refactor workflow E to improve performance because of F
