### PR TITLE
fix: check null primary address when pick new one

### DIFF
--- a/lib/screen/bloc/router/router_bloc.dart
+++ b/lib/screen/bloc/router/router_bloc.dart
@@ -175,13 +175,18 @@ class RouterBloc extends AuBloc<RouterEvent, RouterState> {
             .initIfDefaultAccount());
         await migrationUtil.migrateIfNeeded();
         try {
+          final primaryAddressInfo =
+              await _addressService.getPrimaryAddressInfo();
           final addresses = await _addressService.getAllAddress();
           if (addresses.isEmpty) {
             await _addressService.deriveAddressesFromAllPersona();
           }
-          final addressInfo = await _addressService.pickAddressAsPrimary();
-          await _addressService.registerPrimaryAddress(
-              info: addressInfo, withDidKey: true);
+
+          if (primaryAddressInfo == null) {
+            final addressInfo = await _addressService.pickAddressAsPrimary();
+            await _addressService.registerPrimaryAddress(
+                info: addressInfo, withDidKey: true);
+          }
         } catch (e, stacktrace) {
           log.info('Error while picking primary address', e, stacktrace);
           // rethrow;


### PR DESCRIPTION
**Description**

- Story link: https://github.com/bitmark-inc/autonomy/issues/<number>

**Describe your changes**

- [ ] Added a function A to process data B
- [ ] Created new column C to store D state
- [ ] Refactor workflow E to improve performance because of F
