### PR TITLE
Fix: Hide burnt artworks from the series detail screen 

### DIFF
--- a/lib/gateway/feralfile_api.dart
+++ b/lib/gateway/feralfile_api.dart
@@ -85,6 +85,7 @@ abstract class FeralFileApi {
     @Query('sortBy') String sortBy = 'index',
     @Query('sortOrder') String sortOrder = 'ASC',
     @Query('isViewable') bool? isViewable,
+    @Query('filterBurned') bool? filterBurned,
   });
 
   @POST('/api/web3/messages/action')

--- a/lib/gateway/feralfile_api.g.dart
+++ b/lib/gateway/feralfile_api.g.dart
@@ -328,6 +328,7 @@ class _FeralFileApi implements FeralFileApi {
     String sortBy = 'index',
     String sortOrder = 'ASC',
     bool? isViewable,
+    bool? filterBurned,
   }) async {
     const _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{
@@ -339,6 +340,7 @@ class _FeralFileApi implements FeralFileApi {
       r'sortBy': sortBy,
       r'sortOrder': sortOrder,
       r'isViewable': isViewable,
+      r'filterBurned': filterBurned
     };
     queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};

--- a/lib/service/feralfile_service.dart
+++ b/lib/service/feralfile_service.dart
@@ -468,8 +468,19 @@ class FeralFileServiceImpl extends FeralFileService {
       return await _fakeSeriesArtworks(seriesId, exhibition,
           offset: offset, limit: limit);
     }
-    FeralFileListResponse<Artwork> artworksResponse = await _feralFileApi
-        .getListArtworks(seriesId: seriesId, offset: offset, limit: limit);
+
+    final FeralFileListResponse<Artwork> artworksResponse;
+    if (seriesId == TRAVESS_MERGE_SERIES_ID) {
+      artworksResponse = await _feralFileApi.getListArtworks(
+          seriesId: seriesId,
+          offset: offset,
+          limit: limit,
+          sortOrder: 'DESC',
+          filterBurned: true);
+    } else {
+      artworksResponse = await _feralFileApi.getListArtworks(
+          seriesId: seriesId, offset: offset, limit: limit);
+    }
 
     if (withSeries) {
       final series = await getSeries(seriesId);

--- a/lib/service/feralfile_service.dart
+++ b/lib/service/feralfile_service.dart
@@ -20,6 +20,7 @@ import 'package:autonomy_flutter/model/ff_list_response.dart';
 import 'package:autonomy_flutter/model/ff_series.dart';
 import 'package:autonomy_flutter/service/account_service.dart';
 import 'package:autonomy_flutter/util/constants.dart';
+import 'package:autonomy_flutter/util/crawl_helper.dart';
 import 'package:autonomy_flutter/util/download_helper.dart';
 import 'package:autonomy_flutter/util/exhibition_ext.dart';
 import 'package:autonomy_flutter/util/log.dart';
@@ -470,7 +471,7 @@ class FeralFileServiceImpl extends FeralFileService {
     }
 
     final FeralFileListResponse<Artwork> artworksResponse;
-    if (seriesId == TRAVESS_MERGE_SERIES_ID) {
+    if (seriesId == CrawlHelper.mergeSeriesID) {
       artworksResponse = await _feralFileApi.getListArtworks(
           seriesId: seriesId,
           offset: offset,

--- a/lib/util/constants.dart
+++ b/lib/util/constants.dart
@@ -238,6 +238,9 @@ const List<String> YOUTUBE_VARIANTS = [
 
 const MAGIC_NUMBER = 168;
 
+const TRAVESS_MERGE_SERIES_ID = '2923bc0a-7276-4f98-adf2-ffcf46d4e958';
+// TODO: update to PRD constant: '0a954c31-d336-4e37-af0f-ec336c064879';
+
 Future<bool> isAppCenterBuild() async {
   final PackageInfo info = await PackageInfo.fromPlatform();
   return info.packageName.contains('inhouse');

--- a/lib/util/constants.dart
+++ b/lib/util/constants.dart
@@ -238,9 +238,6 @@ const List<String> YOUTUBE_VARIANTS = [
 
 const MAGIC_NUMBER = 168;
 
-const TRAVESS_MERGE_SERIES_ID = '2923bc0a-7276-4f98-adf2-ffcf46d4e958';
-// TODO: update to PRD constant: '0a954c31-d336-4e37-af0f-ec336c064879';
-
 Future<bool> isAppCenterBuild() async {
   final PackageInfo info = await PackageInfo.fromPlatform();
   return info.packageName.contains('inhouse');

--- a/lib/util/crawl_helper.dart
+++ b/lib/util/crawl_helper.dart
@@ -7,4 +7,10 @@ class CrawlHelper {
         .getConfig(ConfigGroup.exhibition, ConfigKey.crawl, {});
     return config['exhibition_id'];
   }
+
+  static String? get mergeSeriesID {
+    final config = injector<RemoteConfigService>()
+        .getConfig(ConfigGroup.exhibition, ConfigKey.crawl, {});
+    return config['merge_series_id'];
+  }
 }


### PR DESCRIPTION
**Description**

- Story link: https://github.com/bitmark-inc/feral-file/issues/2733

**Describe your changes**

- [x] add filterBurned get artworks of series for merge artworks