### PR TITLE
fix: handle swipe down to hide artwork info

### DIFF
--- a/lib/screen/detail/artwork_detail_page.dart
+++ b/lib/screen/detail/artwork_detail_page.dart
@@ -244,11 +244,22 @@ class _ArtworkDetailPageState extends State<ArtworkDetailPage>
 
   void _infoExpand() {
     _scrollController?.jumpTo(0);
-    _scrollController ??= ScrollController();
+    if (_scrollController == null) {
+      _initScrollController();
+    }
     setState(() {
       _isInfoExpand = true;
     });
     _animationController.animateTo(_infoExpandPosition);
+  }
+
+  void _initScrollController() {
+    _scrollController = ScrollController();
+    _scrollController!.addListener(() {
+      if (_scrollController!.position.pixels < -20 && _isInfoExpand) {
+        _infoShrink();
+      }
+    });
   }
 
   @override
@@ -422,8 +433,11 @@ class _ArtworkDetailPageState extends State<ArtworkDetailPage>
                             _infoShrink();
                           }
                         },
-                        child: _infoHeader(context, asset, artistName,
-                            state.isViewOnly, canvasState),
+                        child: Container(
+                          color: Colors.transparent,
+                          child: _infoHeader(context, asset, artistName,
+                              state.isViewOnly, canvasState),
+                        ),
                       ),
                     ),
             ),
@@ -433,6 +447,12 @@ class _ArtworkDetailPageState extends State<ArtworkDetailPage>
                 child: GestureDetector(
                   behavior: HitTestBehavior.translucent,
                   onTap: _infoShrink,
+                  onVerticalDragEnd: (details) {
+                    final dy = details.primaryVelocity ?? 0;
+                    if (dy > 0) {
+                      _infoShrink();
+                    }
+                  },
                   child: Container(
                     color: Colors.transparent,
                     height: MediaQuery.of(context).size.height / 2 -
@@ -551,6 +571,7 @@ class _ArtworkDetailPageState extends State<ArtworkDetailPage>
             )),
         SingleChildScrollView(
           controller: _scrollController,
+          physics: const BouncingScrollPhysics(),
           child: SizedBox(
             width: double.infinity,
             child: Column(

--- a/lib/screen/feralfile_artwork_preview/feralfile_artwork_preview_page.dart
+++ b/lib/screen/feralfile_artwork_preview/feralfile_artwork_preview_page.dart
@@ -202,8 +202,11 @@ class _FeralFileArtworkPreviewPageState
                               _infoShrink();
                             }
                           },
-                          child: _infoHeader(
-                              context, widget.payload.artwork, canvasState),
+                          child: Container(
+                            color: Colors.transparent,
+                            child: _infoHeader(
+                                context, widget.payload.artwork, canvasState),
+                          ),
                         ),
                       ),
               ));
@@ -246,11 +249,22 @@ class _FeralFileArtworkPreviewPageState
 
   void _infoExpand() {
     _scrollController?.jumpTo(0);
-    _scrollController ??= ScrollController();
+    if (_scrollController == null) {
+      _initScrollController();
+    }
     setState(() {
       _isInfoExpand = true;
     });
     _animationController.animateTo(_infoExpandPosition);
+  }
+
+  void _initScrollController() {
+    _scrollController = ScrollController();
+    _scrollController!.addListener(() {
+      if (_scrollController!.position.pixels < -20 && _isInfoExpand) {
+        _infoShrink();
+      }
+    });
   }
 
   Widget _artworkInfoIcon() => Semantics(
@@ -406,6 +420,7 @@ class _FeralFileArtworkPreviewPageState
         )),
         SingleChildScrollView(
           controller: _scrollController,
+          physics: const BouncingScrollPhysics(),
           child: SizedBox(
             width: double.infinity,
             child: Column(


### PR DESCRIPTION
**Description**

- Story link: https://bitmark.slack.com/archives/C02RN1D4EG0/p1722509452768019

**Describe your changes**

- [ ] handle swipe gesture in artwork detail
