### PR TITLE
fix: mapping url and medium to avoid mismatch rendering type

### DIFF
--- a/lib/screen/feralfile_artwork_preview/feralfile_artwork_preview_bloc.dart
+++ b/lib/screen/feralfile_artwork_preview/feralfile_artwork_preview_bloc.dart
@@ -4,7 +4,6 @@ import 'package:autonomy_flutter/util/exhibition_ext.dart';
 
 class FFArtworkPreviewBloc
     extends AuBloc<FFArtworkPreviewEvent, FFArtworkPreviewState> {
-
   FFArtworkPreviewBloc() : super(FFArtworkPreviewState()) {
     on<FFArtworkPreviewConfigByArtwork>((event, emit) async {
       if (!state.mediumMap.containsKey(event.artwork.previewURL)) {

--- a/lib/screen/feralfile_artwork_preview/feralfile_artwork_preview_bloc.dart
+++ b/lib/screen/feralfile_artwork_preview/feralfile_artwork_preview_bloc.dart
@@ -4,10 +4,16 @@ import 'package:autonomy_flutter/util/exhibition_ext.dart';
 
 class FFArtworkPreviewBloc
     extends AuBloc<FFArtworkPreviewEvent, FFArtworkPreviewState> {
+
   FFArtworkPreviewBloc() : super(FFArtworkPreviewState()) {
     on<FFArtworkPreviewConfigByArtwork>((event, emit) async {
-      final medium = await event.artwork.renderingType();
-      emit(state.copyWith(medium: medium));
+      if (!state.mediumMap.containsKey(event.artwork.previewURL)) {
+        final medium = await event.artwork.renderingType();
+        final Map<String, String> mediumMap = {};
+        mediumMap[event.artwork.previewURL] = medium;
+        mediumMap.addEntries(state.mediumMap.entries);
+        emit(state.copyWith(mediumMap: mediumMap));
+      }
     });
   }
 }

--- a/lib/screen/feralfile_artwork_preview/feralfile_artwork_preview_state.dart
+++ b/lib/screen/feralfile_artwork_preview/feralfile_artwork_preview_state.dart
@@ -11,14 +11,14 @@ class FFArtworkPreviewConfigByArtwork extends FFArtworkPreviewEvent {
 /// -----------------------------------
 
 class FFArtworkPreviewState {
-  final String? medium;
+  final Map<String, String> mediumMap;
 
-  FFArtworkPreviewState({this.medium});
+  FFArtworkPreviewState({this.mediumMap = const {}});
 
   FFArtworkPreviewState copyWith({
-    String? medium,
+    Map<String, String>? mediumMap,
   }) =>
       FFArtworkPreviewState(
-        medium: medium ?? this.medium,
+        mediumMap: mediumMap ?? this.mediumMap,
       );
 }

--- a/lib/view/feralfile_artwork_preview_widget.dart
+++ b/lib/view/feralfile_artwork_preview_widget.dart
@@ -106,7 +106,7 @@ class _FeralfileArtworkPreviewWidgetState
           return BlocBuilder<FFArtworkPreviewBloc, FFArtworkPreviewState>(
             bloc: context.read<FFArtworkPreviewBloc>(),
             builder: (context, state) {
-              final medium = state.medium;
+              final medium = state.mediumMap[previewUrl];
               if (medium == null) {
                 return const SizedBox();
               }


### PR DESCRIPTION
**Description**

- Story link: https://github.com/bitmark-inc/autonomy/issues/<number>

**Describe your changes**

- [ ] mapping url and medium to avoid mismatch rendering type
