### PR TITLE
fix: send event open app after restoreIfNeeded

### DIFF
--- a/lib/screen/onboarding_page.dart
+++ b/lib/screen/onboarding_page.dart
@@ -14,6 +14,7 @@ import 'package:autonomy_flutter/service/configuration_service.dart';
 import 'package:autonomy_flutter/service/deeplink_service.dart';
 import 'package:autonomy_flutter/service/metric_client_service.dart';
 import 'package:autonomy_flutter/util/log.dart';
+import 'package:autonomy_flutter/util/metric_helper.dart';
 import 'package:autonomy_flutter/view/back_appbar.dart';
 import 'package:autonomy_flutter/view/primary_button.dart';
 import 'package:autonomy_flutter/view/responsive.dart';
@@ -73,10 +74,12 @@ class _OnboardingPageState extends State<OnboardingPage>
 
   Future<void> _createAccountOrRestoreIfNeeded() async {
     await injector<AccountService>().restoreIfNeeded();
+    await metricClient.identity();
+    // count open app
+    await metricClient.addEvent(MetricEventName.openApp.name);
     if (!mounted) {
       return;
     }
-    await metricClient.identity();
     await _goToTargetScreen(context);
   }
 

--- a/lib/service/metric_client_service.dart
+++ b/lib/service/metric_client_service.dart
@@ -19,9 +19,6 @@ class MetricClientService {
 
   Future<void> initService({String? identifier}) async {
     _identifier = identifier ?? _defaultIdentifier();
-
-    // count open app
-    await addEvent(MetricEventName.openApp.name);
   }
 
   Future<void> identity() async {

--- a/lib/util/error_handler.dart
+++ b/lib/util/error_handler.dart
@@ -276,7 +276,9 @@ Future<bool> showErrorDialogFromException(Object exception,
     return true;
   }
 
-  log.warning('Unhandled error: $exception', exception, stackTrace);
+  log
+    ..warning('Unhandled error: $exception', exception, stackTrace)
+    ..warning(stackTrace);
 
   if (library != null || onlySentryException(exception)) {
     // Send error directly to Sentry if it comes from specific libraries


### PR DESCRIPTION
**Description**

- Story link: https://github.com/bitmark-inc/autonomy/issues/<number>

**Describe your changes**

- [ ] Added a function A to process data B
- [ ] Created new column C to store D state
- [ ] Refactor workflow E to improve performance because of F
