### PR TITLE
fix: ignore platform exception and add sentry when restore/backup failed

### DIFF
--- a/lib/service/deeplink_service.dart
+++ b/lib/service/deeplink_service.dart
@@ -336,7 +336,9 @@ class DeeplinkServiceImpl extends DeeplinkService {
         final response =
             await _branchApi.getParams(Environment.branchKey, link);
         await handleBranchDeeplinkData(response['data'], onFinish: onFinish);
-      } catch (e) {
+      } catch (e, s) {
+        unawaited(Sentry.captureException('Branch deeplink error: $e',
+            stackTrace: s));
         log.info('[DeeplinkService] _handleBranchDeeplink error $e');
         await _navigationService.showCannotResolveBranchLink();
       }

--- a/lib/util/android_backup_channel.dart
+++ b/lib/util/android_backup_channel.dart
@@ -5,10 +5,12 @@
 //  that can be found in the LICENSE file.
 //
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:autonomy_flutter/util/log.dart';
 import 'package:flutter/services.dart';
+import 'package:sentry/sentry.dart';
 
 class AndroidBackupChannel {
   static const MethodChannel _channel = MethodChannel('backup');
@@ -19,7 +21,13 @@ class AndroidBackupChannel {
   Future backupKeys(List<String> uuids) async {
     try {
       await _channel.invokeMethod('backupKeys', {'uuids': uuids});
-    } catch (e) {
+    } catch (e, s) {
+      unawaited(
+        Sentry.captureException(
+          'Android Backup Error: $e',
+          stackTrace: s,
+        ),
+      );
       log.warning('Android cloud backup error', e);
     }
   }
@@ -33,7 +41,13 @@ class AndroidBackupChannel {
       final backupData = json.decode(data);
       final accounts = BackupData.fromJson(backupData).accounts;
       return accounts;
-    } catch (e) {
+    } catch (e, s) {
+      unawaited(
+        Sentry.captureException(
+          'Android Restore Keys Error: $e',
+          stackTrace: s,
+        ),
+      );
       log.warning('Android cloud backup error', e);
       return [];
     }
@@ -42,7 +56,11 @@ class AndroidBackupChannel {
   Future deleteBlockStoreData() async {
     try {
       await _channel.invokeMethod('deleteKeys', {});
-    } catch (e) {
+    } catch (e, s) {
+      unawaited(Sentry.captureException(
+        'Android Delete BlocStore Data Error: $e',
+        stackTrace: s,
+      ));
       log.warning('Android cloud backup error', e);
     }
   }

--- a/lib/util/error_handler.dart
+++ b/lib/util/error_handler.dart
@@ -322,7 +322,9 @@ Future<bool> showErrorDialogFromException(Object exception,
 }
 
 bool _isErrorIgnored(Object exception) {
-  if (exception is RangeError || exception is FlutterError) {
+  if (exception is RangeError ||
+      exception is FlutterError ||
+      exception is PlatformException) {
     return true;
   }
   return false;


### PR DESCRIPTION
**Description**

- Story link: https://github.com/bitmark-inc/autonomy/issues/<number>

**Describe your changes**

- [ ] Added a function A to process data B
- [ ] Created new column C to store D state
- [ ] Refactor workflow E to improve performance because of F
