### PR TITLE
hide global error, onboarding time out popup

### DIFF
--- a/lib/screen/onboarding_page.dart
+++ b/lib/screen/onboarding_page.dart
@@ -16,7 +16,6 @@ import 'package:autonomy_flutter/service/configuration_service.dart';
 import 'package:autonomy_flutter/service/deeplink_service.dart';
 import 'package:autonomy_flutter/service/device_info_service.dart';
 import 'package:autonomy_flutter/service/metric_client_service.dart';
-import 'package:autonomy_flutter/service/navigation_service.dart';
 import 'package:autonomy_flutter/service/notification_service.dart';
 import 'package:autonomy_flutter/service/remote_config_service.dart';
 import 'package:autonomy_flutter/util/dailies_helper.dart';
@@ -64,7 +63,7 @@ class _OnboardingPageState extends State<OnboardingPage>
     _timer = Timer(const Duration(seconds: 10), () {
       log.info('OnboardingPage loading more than 10s');
       unawaited(Sentry.captureMessage('OnboardingPage loading more than 10s'));
-      unawaited(injector<NavigationService>().showAppLoadError());
+      // unawaited(injector<NavigationService>().showAppLoadError());
     });
     unawaited(setup(context).then((_) => _fetchRuntimeCache()));
   }

--- a/lib/util/error_handler.dart
+++ b/lib/util/error_handler.dart
@@ -312,7 +312,8 @@ Future<bool> showErrorDialogFromException(Object exception,
       return true;
     } else {
       if (!_isErrorIgnored(exception)) {
-        navigationService.showErrorDialog(event);
+        // navigationService.showErrorDialog(event);
+        await Sentry.captureException(exception, stackTrace: stackTrace);
       }
       return true;
     }
@@ -325,7 +326,9 @@ bool _isErrorIgnored(Object exception) {
   if (exception is RangeError ||
       exception is FlutterError ||
       exception is PlatformException) {
-    return true;
+    // set this to false because we won't show popup then we need to send to
+    // sentry all errors
+    return false;
   }
   return false;
 }

--- a/lib/util/error_handler.dart
+++ b/lib/util/error_handler.dart
@@ -313,7 +313,6 @@ Future<bool> showErrorDialogFromException(Object exception,
     } else {
       if (!_isErrorIgnored(exception)) {
         // navigationService.showErrorDialog(event);
-        await Sentry.captureException(exception, stackTrace: stackTrace);
       }
       return true;
     }
@@ -326,9 +325,7 @@ bool _isErrorIgnored(Object exception) {
   if (exception is RangeError ||
       exception is FlutterError ||
       exception is PlatformException) {
-    // set this to false because we won't show popup then we need to send to
-    // sentry all errors
-    return false;
+    return true;
   }
   return false;
 }


### PR DESCRIPTION
**Description**

- Story link: 

**Describe your changes**

- [x] hide global error, onboarding time out popup, send to Sentry instead