### PR TITLE
fix: update thumbnail cache size

### DIFF
--- a/lib/screen/feralfile_series/feralfile_series_page.dart
+++ b/lib/screen/feralfile_series/feralfile_series_page.dart
@@ -121,6 +121,7 @@ class _FeralFileSeriesPageState extends State<FeralFileSeriesPage> {
     final cacheWidth =
         (MediaQuery.sizeOf(context).width - _padding * 2 - _axisSpacing * 2) ~/
             3;
+    final cacheHeight = (cacheWidth / ratio).toInt();
     return Padding(
       padding:
           const EdgeInsets.only(left: _padding, right: _padding, bottom: 20),
@@ -139,8 +140,8 @@ class _FeralFileSeriesPageState extends State<FeralFileSeriesPage> {
             builderDelegate: PagedChildBuilderDelegate<Artwork>(
               itemBuilder: (context, artwork, index) => FFArtworkThumbnailView(
                 artwork: artwork,
-                // cacheWidth: cacheWidth,
-                // cacheHeight: cacheHeight,
+                cacheWidth: cacheWidth,
+                cacheHeight: cacheHeight,
                 onTap: () async {
                   final displayKey = series.displayKey;
                   final lastSelectedCanvasDevice = _canvasDeviceBloc.state


### PR DESCRIPTION
**Description**

- Story link: [[Bug] FFapp - Crashes when opened on a low-hardware Android device and takes long time in iOS when loading some series of exhibitions](https://github.com/bitmark-inc/feralfile-app/issues/2186)

**Describe your changes**

- [ ] Added a function A to process data B
- [ ] Created new column C to store D state
- [ ] Refactor workflow E to improve performance because of F
