### PR TITLE
fallback to webview for gif

### DIFF
--- a/lib/nft_rendering/nft_rendering_widget.dart
+++ b/lib/nft_rendering/nft_rendering_widget.dart
@@ -377,9 +377,25 @@ class GifNFTRenderingWidget extends INFTRenderingWidget {
         previewURL,
         loadingBuilder: _loadingBuilder,
         errorBuilder: (context, url, error) => Center(
-          child: errorWidget,
+          child: _fallbackWebview(),
         ),
         fit: BoxFit.cover,
+      );
+
+  Widget _fallbackWebview() => FeralFileWebview(
+        key: Key('FeralFileWebview_$previewURL'),
+        uri: Uri.parse(overriddenHtml != null ? 'about:blank' : previewURL),
+        onResourceError: (controller, error) {
+          Sentry.captureException(
+            error,
+            stackTrace: StackTrace.current,
+            hint: Hint.withMap({
+              'url': previewURL,
+              'overriddenHtml': overriddenHtml,
+            }),
+          );
+          log.info('Error when load gif with webview: $error on $previewURL');
+        },
       );
 }
 

--- a/lib/nft_rendering/nft_rendering_widget.dart
+++ b/lib/nft_rendering/nft_rendering_widget.dart
@@ -382,20 +382,22 @@ class GifNFTRenderingWidget extends INFTRenderingWidget {
         fit: BoxFit.cover,
       );
 
-  Widget _fallbackWebview() => FeralFileWebview(
-        key: Key('FeralFileWebview_$previewURL'),
-        uri: Uri.parse(overriddenHtml != null ? 'about:blank' : previewURL),
-        onResourceError: (controller, error) {
-          Sentry.captureException(
-            error,
-            stackTrace: StackTrace.current,
-            hint: Hint.withMap({
-              'url': previewURL,
-              'overriddenHtml': overriddenHtml,
-            }),
-          );
-          log.info('Error when load gif with webview: $error on $previewURL');
-        },
+  Widget _fallbackWebview() => Center(
+        child: FeralFileWebview(
+          key: Key('FeralFileWebview_$previewURL'),
+          uri: Uri.parse(overriddenHtml != null ? 'about:blank' : previewURL),
+          onResourceError: (controller, error) {
+            Sentry.captureException(
+              error,
+              stackTrace: StackTrace.current,
+              hint: Hint.withMap({
+                'url': previewURL,
+                'overriddenHtml': overriddenHtml,
+              }),
+            );
+            log.info('Error when load gif with webview: $error on $previewURL');
+          },
+        ),
       );
 }
 


### PR DESCRIPTION
**Description**

- Story link: https://github.com/bitmark-inc/feralfile-app/issues/2245

**Describe your changes**

- [x] fallback to webview if load gif artwork failed